### PR TITLE
Use member?/2 instead of find/2 for lookup

### DIFF
--- a/lib/fast_ensure_loaded.ex
+++ b/lib/fast_ensure_loaded.ex
@@ -11,7 +11,7 @@ defmodule FastEnsureLoaded do
   def ensure_loaded(module) do
     module_list = FastGlobal.get(:fast_ensure_loaded) || []
 
-    if Enum.find(module_list, fn x -> x == module end) do
+    if Enum.member?(module_list, module) do
       :ok
     else
       load_and_store_module(module)


### PR DESCRIPTION
For lists, the `Enum.member?/2` function is a bit faster than `Enum.find/2`.

It simply wraps the `lists:member/2` function from Erlang.